### PR TITLE
Remove support for legacy enum and struct window to support IDA 9.x

### DIFF
--- a/InTooDeep.py
+++ b/InTooDeep.py
@@ -18,15 +18,11 @@ def getTreeForWidget(widget):
         
         idaapi.BWN_DISASM: ida_dirtree.DIRTREE_FUNCS,
         
-        idaapi.BWN_ENUMS: ida_dirtree.DIRTREE_ENUMS,
-        
         idaapi.BWN_IMPORTS: ida_dirtree.DIRTREE_IMPORTS,
         
         idaapi.BWN_LOCTYPS: ida_dirtree.DIRTREE_LOCAL_TYPES,
             
         idaapi.BWN_NAMES: ida_dirtree.DIRTREE_NAMES,
-            
-        idaapi.BWN_STRUCTS: ida_dirtree.DIRTREE_STRUCTS,
     }.get(widget, None)
 
 


### PR DESCRIPTION
When I have tried to use this plugin on IDA 9.0 (and IDA 9.0 SP1), I have experienced following error whenever I right-click anything on the IDA.

```
Traceback (most recent call last):
  File "C:/Users/saburo/AppData/Roaming/Hex-Rays/IDA Pro/plugins/InToDeep.py", line 153, in finish_populating_widget_popup
    treeType = getTreeForWidget(widgetType)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/Users/saburo/AppData/Roaming/Hex-Rays/IDA Pro/plugins/InToDeep.py", line 21, in getTreeForWidget
    idaapi.BWN_ENUMS: ida_dirtree.DIRTREE_ENUMS,
    ^^^^^^^^^^^^^^^^
AttributeError: module 'idaapi' has no attribute 'BWN_ENUMS'
```

```
Traceback (most recent call last):
  File "C:/Users/saburo/AppData/Roaming/Hex-Rays/IDA Pro/plugins/InToDeep.py", line 151, in finish_populating_widget_popup
    treeType = getTreeForWidget(widgetType)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/Users/saburo/AppData/Roaming/Hex-Rays/IDA Pro/plugins/InToDeep.py", line 27, in getTreeForWidget
    idaapi.BWN_STRUCTS: ida_dirtree.DIRTREE_STRUCTS,
    ^^^^^^^^^^^^^^^^^^
AttributeError: module 'idaapi' has no attribute 'BWN_STRUCTS'
```

I believe these error occurs because IDA 9.x removes legacy Enums and Structures view (they have been entirely replaced to Local Types view). This PR will remove support for legacy views, to ensure this plugin works on IDA 9.x environment (tested on IDA 9.0 and IDA 9.0 SP1).
